### PR TITLE
More convenient to switch channel

### DIFF
--- a/channelwidget.cpp
+++ b/channelwidget.cpp
@@ -64,9 +64,9 @@ void ChannelWidget::on_prevButton_clicked()
     if (ui->slider->currentIndex() == 0) return;
     if (!doubanfm.hasLogin() && ui->slider->currentIndex() == 1) return;
     ui->slider->scrollToIndex(ui->slider->currentIndex() - 1);
-    QLabel *pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex()]);
+    QLabel *pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex() + 1]);
     pnt->setText(pnt->text().replace("white", "grey").replace("<b>", "<a>").replace("</b>", "</a>"));
-    pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex() - 1]);
+    pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex()]);
     pnt->setText(pnt->text().replace("grey", "white").replace("<a>", "<b>").replace("</a>", "</b>"));
 }
 
@@ -74,9 +74,9 @@ void ChannelWidget::on_nextButton_clicked()
 {
     if (ui->slider->currentIndex() == ui->slider->numberOfChildren() - 1) return;
     ui->slider->scrollToIndex(ui->slider->currentIndex() + 1);
-    QLabel *pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex()]);
+    QLabel *pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex() - 1]);
     pnt->setText(pnt->text().replace("white", "grey").replace("<b>", "<a>").replace("</b>", "</a>"));
-    pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex() + 1]);
+    pnt = static_cast<QLabel *>(labels[ui->slider->currentIndex()]);
     pnt->setText(pnt->text().replace("grey", "white").replace("<a>", "<b>").replace("</a>", "</b>"));
 }
 
@@ -105,4 +105,12 @@ void ChannelWidget::setChannels(const QList<DoubanChannel>& channels) {
 
 void ChannelWidget::leaveEvent(QEvent *) {
     emit mouseLeave();
+}
+
+void ChannelWidget::wheelEvent(QWheelEvent *ev){
+    if(ev->angleDelta().y()<0){
+        on_nextButton_clicked();
+    }else{
+        on_prevButton_clicked();
+    }
 }

--- a/channelwidget.h
+++ b/channelwidget.h
@@ -21,7 +21,7 @@ public:
     ~ChannelWidget();
 
     void leaveEvent(QEvent *ev);
-
+    void wheelEvent(QWheelEvent *ev);
 public slots:
     void setChannels(const QList<DoubanChannel>& channels);
 

--- a/horizontalslider.cpp
+++ b/horizontalslider.cpp
@@ -40,6 +40,8 @@ void HorizontalSlider::scrollToIndex(int index) {
     if (index == curIndex) return;
     if (index > numberOfChildren() - 1) return;
 
+    this->curIndex = index;
+
     QPropertyAnimation *anim = new QPropertyAnimation(container, "geometry");
     anim->setDuration(300);
     anim->setStartValue(container->geometry());
@@ -54,7 +56,6 @@ void HorizontalSlider::scrollToIndex(int index) {
     anim->setEndValue(endval);
     anim->setEasingCurve(QEasingCurve::OutCubic);
     connect(anim, &QPropertyAnimation::finished, [=] () {
-        this->curIndex = index;
         emit scrollFinished();
     });
     anim->start(QAbstractAnimation::DeleteWhenStopped);


### PR DESCRIPTION
1.modify horizontalslider::scorllToIndex  set curIndex dont wait the
animation finished
2.use mouse wheelEvent switch channel

添加使用滚轮切换频道
issue#14 提到切换频道不方便，horizontalslider的切换是等到动画执行完毕才完成，如果快速点击切换会有卡住的感觉，我改成先给curIndex赋值，不会有卡的感觉了。
