### PR TITLE
fix translation; fix exe file icon  (for Windows)

### DIFF
--- a/data/win32/winrc.rc
+++ b/data/win32/winrc.rc
@@ -1,1 +1,1 @@
-IDI_ICON1               ICON    DISCARDABLE     "QDoubanFM.ico"
+IDI_ICON1               ICON    DISCARDABLE     "../../QDoubanFM.ico"

--- a/main.cpp
+++ b/main.cpp
@@ -12,10 +12,10 @@ const QString LOCAL_SOCKET_NAME = "QDoubanFM_LocalSocket";
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
-    if(true){
-        QTranslator translator;
-        translator.load("i18n/zh_CN.qm");
-        a.installTranslator(&translator);
+    if (true) {
+        auto translator = new QTranslator(&a);
+        translator->load("zh_CN", QApplication::applicationDirPath() + "/i18n");
+        a.installTranslator(translator);
         //此地暂作这样的处理，以后可以增加语言切换功能
     }
     QLocalSocket socket;


### PR DESCRIPTION
`bool QApplication::installTranslator(QTranslator* ptr)` 不会对 ptr 所指向的实例进行拷贝。

之前的代码：
```
if (true) {
    QTranslator translator;
    translator.load("i18n/zh_CN.qm");
    a.installTranslator(&translator);
    // translator 将被析构，而翻译尚未完成
}
```