### PR TITLE
修复翻译问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 如果你喜欢本项目的话，给我买瓶啤酒喝好不;)
 
 <!--支付宝已经下线了这个功能
-<a href='http://me.alipay.com/zonyitoo'> <img src='https://img.alipay.com/sys/personalprod/style/mc/btn-index.png' /> </a> 
+<a href='http://me.alipay.com/zonyitoo'> <img src='https://img.alipay.com/sys/personalprod/style/mc/btn-index.png' /> </a>
 -->
 
 ![支付宝](https://tfsimg.alipay.com/images/mobilecodec/T1nwBdXXdlXXXXXXXX)
@@ -42,6 +42,7 @@
 
 ```bash
 lupdate doubanfm-qt.pro
+lrelease doubanfm-qt.pro
 qmake doubanfm-qt.pro
 make
 ```

--- a/controlpanel.ui
+++ b/controlpanel.ui
@@ -277,23 +277,11 @@
   <widget class="VolumeTimePanel" name="volumeTime" native="true">
    <property name="geometry">
     <rect>
-     <x>420</x>
+     <x>404</x>
      <y>107</y>
-     <width>85</width>
-     <height>16</height>
+     <width>101</width>
+     <height>20</height>
     </rect>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>85</width>
-     <height>16</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>85</width>
-     <height>16</height>
-    </size>
    </property>
   </widget>
   <widget class="QLabel" name="album">

--- a/i18n/zh_CN.ts
+++ b/i18n/zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="zh_CN" sourcelanguage="en_US">
+<TS version="2.1" language="zh_CN" sourcelanguage="en_US">
 <context>
     <name>AlbumWidget</name>
     <message>
@@ -36,12 +36,12 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../controlpanel.ui" line="374"/>
+        <location filename="../controlpanel.ui" line="362"/>
         <source>&lt;font color=white&gt;Channels&lt;/font&gt;</source>
         <translation>&lt;font color=white&gt;频&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;道&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../controlpanel.ui" line="436"/>
+        <location filename="../controlpanel.ui" line="424"/>
         <source>Lyric</source>
         <translation>歌     词</translation>
     </message>
@@ -179,12 +179,7 @@
 <context>
     <name>VolumeTimePanel</name>
     <message>
-        <location filename="../volumetimepanel.ui" line="26"/>
-        <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../volumetimepanel.ui" line="52"/>
+        <location filename="../volumetimepanel.ui" line="31"/>
         <source>0:00</source>
         <translation></translation>
     </message>

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@
 #include <QApplication>
 #include <QLocalSocket>
 #include <QLocalServer>
+#include <QTranslator>
+#include <QLocale>
 
 #include "plugins/plugin.hpp"
 
@@ -60,6 +62,16 @@ int main(int argc, char *argv[])
         qDebug() << "Raise window";
     });
     server.listen(LOCAL_SOCKET_NAME);
+
+    // i18n
+    QTranslator qtTranslator;
+    qtTranslator.load("qt_" + QLocale::system().name(),
+            QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    a.installTranslator(&qtTranslator);
+
+    QTranslator myappTranslator;
+    myappTranslator.load("i18n/" + QLocale::system().name());
+    a.installTranslator(&myappTranslator);
 
     return a.exec();
 }

--- a/volumetimepanel.ui
+++ b/volumetimepanel.ui
@@ -6,39 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>85</width>
-    <height>16</height>
+    <width>102</width>
+    <height>20</height>
    </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>85</width>
-    <height>16</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>85</width>
-    <height>16</height>
-   </size>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
   </property>
   <widget class="QLabel" name="tick">
    <property name="geometry">
     <rect>
-     <x>32</x>
-     <y>1</y>
+     <x>43</x>
+     <y>0</y>
      <width>32</width>
-     <height>16</height>
+     <height>20</height>
     </rect>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>16777215</width>
-     <height>16777215</height>
-    </size>
    </property>
    <property name="font">
     <font>
@@ -58,10 +37,10 @@
   <widget class="QLabel" name="volumeImg">
    <property name="geometry">
     <rect>
-     <x>71</x>
-     <y>3</y>
-     <width>14</width>
-     <height>12</height>
+     <x>80</x>
+     <y>0</y>
+     <width>20</width>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">
@@ -77,10 +56,10 @@
   <widget class="QSlider" name="volume">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>5</y>
-     <width>61</width>
-     <height>7</height>
+     <x>25</x>
+     <y>0</y>
+     <width>75</width>
+     <height>20</height>
     </rect>
    </property>
    <property name="styleSheet">


### PR DESCRIPTION
在 main.cpp 里添加了加载翻译文件的代码。

编译的时候，应该运行 lrelease doubanfm-qt.pro 将 *.ts 编译成 *.qm。

安装的时候，应该将 i18n 文件夹也复制过去，因为翻译文件是运行时动态加载的，没有编译到二进制程序里。

看了下 openSUSE 的打包脚本，发现没有 lupdate 和 lrelease，i18n 文件夹也没有复制过去。

![spectacle q26912](https://cloud.githubusercontent.com/assets/5836790/15269401/16a2d8c0-1a06-11e6-94c1-4863b43fa4fc.png)
