### PR TITLE
点击托盘图标隐藏，显示窗口，并将窗口提到最前

### DIFF
--- a/mainwidget.cpp
+++ b/mainwidget.cpp
@@ -71,8 +71,18 @@ MainWidget::MainWidget(QWidget *parent) :
     if (QSystemTrayIcon::isSystemTrayAvailable()) {
         systemTrayIcon = new QSystemTrayIcon(QIcon("://icon.png"), this);
         connect(systemTrayIcon, &QSystemTrayIcon::activated, [&] () {
-            if (this->isHidden())
+            if (this->isHidden()) {
                 this->show();
+                this->raise();
+                this->activateWindow();
+            } else {
+                if (this->isActiveWindow()) {
+                    this->hide();
+                } else {
+                    this->raise();
+                    this->activateWindow();
+                }
+            }
         });
         QMenu *trayMenu = new QMenu(this);
         auto _openAction = trayMenu->addAction(tr("Open main window"));


### PR DESCRIPTION
#49

在 KDE 上测试有效，不知道 Windows 和 OS X 上如何。

点击托盘图标会有以下行为：
- 如果窗口隐藏，则显示窗口。
- 如果窗口显示在最前（窗口焦点），则隐藏窗口。
- 如果窗口显示在后面（无窗口焦点），则将窗口移到最前。

参考的 Amarok 的设计。
